### PR TITLE
Edit and delete location

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,7 +14,7 @@ model User {
   id                     String             @id @default(cuid())
   f_name                 String
   l_name                 String
-  location               LocationsCovered   @relation(fields: [locationsCoveredId], references: [id], onDelete: Cascade)
+  location               LocationsCovered   @relation(fields: [locationsCoveredId], references: [id])
   locationsCoveredId     String
   gender                 String
   email                  String?            @unique
@@ -138,7 +138,7 @@ model LocationCoordinates {
   lat                Float
   lng                Float
   location           LocationsCovered @relation(fields: [locationsCoveredId], references: [id], onDelete: Cascade)
-  locationsCoveredId String
+  locationsCoveredId String           @unique
   createdAt          DateTime         @default(now())
   updatedAt          DateTime         @updatedAt
 }

--- a/src/locations/dto/delete-location.dto.ts
+++ b/src/locations/dto/delete-location.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class DeleteLocationDto {
+  @IsNotEmpty()
+  @IsString()
+  id: string;
+}

--- a/src/locations/dto/update-location.dto.ts
+++ b/src/locations/dto/update-location.dto.ts
@@ -1,4 +1,8 @@
-import { PartialType } from '@nestjs/mapped-types';
+import { IsNotEmpty, IsString } from 'class-validator';
 import { CreateLocationDto } from './create-location.dto';
 
-export class UpdateLocationDto extends PartialType(CreateLocationDto) {}
+export class UpdateLocationDto extends CreateLocationDto {
+  @IsNotEmpty()
+  @IsString()
+  id: string;
+}

--- a/src/locations/events/location-updated.dto.ts
+++ b/src/locations/events/location-updated.dto.ts
@@ -1,0 +1,6 @@
+export class LocationUpdatedEvent {
+  constructor(
+    public readonly locationsCoveredId: string,
+    public readonly location_name: string,
+  ) {}
+}

--- a/src/locations/locations.controller.spec.ts
+++ b/src/locations/locations.controller.spec.ts
@@ -4,6 +4,7 @@ import { LocationsService } from './locations.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateLocationDto } from './dto/create-location.dto';
 import { UserHelper } from '../helpers/user-helper';
+import { UpdateLocationDto } from './dto/update-location.dto';
 
 describe('LocationsController', () => {
   const service = {
@@ -22,6 +23,17 @@ describe('LocationsController', () => {
         updatedAt: new Date(),
       },
     ]),
+
+    updateLocationFn: jest.fn().mockImplementation(async () => ({
+      id: '12345678',
+      location_name: 'sample',
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })),
+
+    deleteLocation: jest.fn().mockImplementation(async () => ({
+      message: 'Location deleted',
+    })),
   };
   let controller: LocationsController;
 
@@ -70,5 +82,34 @@ describe('LocationsController', () => {
     ]);
 
     expect(service.findAll).toHaveBeenCalled();
+  });
+
+  it('should update a location', async () => {
+    const location: UpdateLocationDto = {
+      location_name: 'sample',
+      id: '12345678',
+    };
+    const updatedLoc = await controller.updateLocation(location);
+
+    expect(updatedLoc).toEqual({
+      id: '12345678',
+      location_name: 'sample',
+      createdAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+    });
+
+    expect(service.updateLocationFn).toHaveBeenCalledWith(location);
+  });
+
+  it('should delete a location', async () => {
+    const id = '123456778';
+
+    const del = await controller.deleteLocation({ id });
+
+    expect(del).toEqual({
+      message: 'Location deleted',
+    });
+
+    expect(service.deleteLocation).toHaveBeenCalledWith(id);
   });
 });

--- a/src/locations/locations.controller.ts
+++ b/src/locations/locations.controller.ts
@@ -1,9 +1,20 @@
-import { Body, Controller, Get, Post, UseGuards } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
 import { UserRoles } from '../decorators/roles/roles.decorator';
 import { RolesGuard } from '../guards/roles/roles.guard';
 import { Roles } from '../users/users.service';
 import { CreateLocationDto } from './dto/create-location.dto';
 import { LocationsService } from './locations.service';
+import { UpdateLocationDto } from './dto/update-location.dto';
+import { DeleteLocationDto } from './dto/delete-location.dto';
 
 @Controller('locations')
 export class LocationsController {
@@ -24,5 +35,19 @@ export class LocationsController {
   @Get('coordinates')
   getCoordinates() {
     return this.locationsService.getCoordinates();
+  }
+
+  @UseGuards(RolesGuard)
+  @UserRoles(Roles.ADMIN)
+  @Patch('update')
+  updateLocation(@Body() location: UpdateLocationDto) {
+    return this.locationsService.updateLocationFn(location);
+  }
+
+  @UseGuards(RolesGuard)
+  @UserRoles(Roles.ADMIN)
+  @Delete('delete')
+  deleteLocation(@Query() data: DeleteLocationDto) {
+    return this.locationsService.deleteLocation(data.id);
   }
 }

--- a/src/locations/locations.module.ts
+++ b/src/locations/locations.module.ts
@@ -22,6 +22,10 @@ export class LocationsModule implements NestModule {
         path: '/locations/all',
         method: RequestMethod.GET,
       })
+      .exclude({
+        path: '/locations/coordinates',
+        method: RequestMethod.GET,
+      })
       .forRoutes(LocationsController);
   }
 }

--- a/src/locations/locations.service.spec.ts
+++ b/src/locations/locations.service.spec.ts
@@ -3,6 +3,7 @@ import { LocationsService } from './locations.service';
 import { PrismaService } from '../prisma/prisma.service';
 import { CreateLocationDto } from './dto/create-location.dto';
 import { EventEmitter2 } from '@nestjs/event-emitter';
+import { UpdateLocationDto } from './dto/update-location.dto';
 
 describe('LocationsService', () => {
   let service: LocationsService;
@@ -23,6 +24,17 @@ describe('LocationsService', () => {
           updatedAt: new Date(),
         },
       ]),
+
+      update: jest.fn().mockImplementation(async () => ({
+        id: '12345678',
+        location_name: 'sample',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })),
+
+      delete: jest.fn().mockImplementation(async () => ({
+        message: 'Location deleted',
+      })),
     },
 
     locationCoordinates: {
@@ -82,5 +94,43 @@ describe('LocationsService', () => {
   it('should find coordinates', async () => {
     const coordinates = await service.getCoordinates();
     expect(coordinates.length).toEqual(1);
+  });
+
+  it('should update a location', async () => {
+    const location: UpdateLocationDto = {
+      location_name: 'sample',
+      id: '12345678',
+    };
+
+    const updatedLocation = await service.updateLocationFn(location);
+
+    expect(updatedLocation).toEqual({
+      id: '12345678',
+      location_name: 'sample',
+      createdAt: expect.any(Date),
+      updatedAt: expect.any(Date),
+    });
+
+    expect(prisma.locationsCovered.update).toHaveBeenCalledWith({
+      where: {
+        id: '12345678',
+      },
+      data: {
+        location_name: location.location_name,
+      },
+    });
+  });
+
+  it('should delete a location', async () => {
+    const id = '12345678';
+    const del = await service.deleteLocation(id);
+    expect(del).toEqual({
+      message: 'Location deleted',
+    });
+    expect(prisma.locationsCovered.delete).toHaveBeenCalledWith({
+      where: {
+        id,
+      },
+    });
   });
 });


### PR DESCRIPTION
- Added edit location functionality
- Added delete location functionality

On edit, an event is emitted that in turns leads to generation of new coordinates that match the edited location. The event then updates the coordinates schema

On delete an event is emitted that deletes coordinates associated with the deleted location